### PR TITLE
performance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,133 +6,396 @@ Checkout our [release notes](https://github.com/aws/aws-dax-go-v2/releases) for
 information about the latest bug fixes, updates, and features added to the SDK.
 
 ## Getting started
+
 The best way to get started working with the SDK is to use go get to add the SDK
 to your Go Workspace manually.
 
     go get github.com/aws/aws-dax-go-v2
 
 ## Making API requests
+
 This example shows how you can use the AWS DAX SDK to make an API request.
 
 ```go
 package main
 
 import (
-    "context"
-    "fmt"
-    "net"
+	"context"
+	"fmt"
+	"net"
 
-    "github.com/aws/aws-dax-go-v2/dax"
-    "github.com/aws/aws-sdk-go-v2/service/dynamodb"
-    "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-    "github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
-    "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-dax-go-v2/dax"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 func main() {
-    ctx := context.Background()
+	ctx := context.Background()
 
-    cfg := dax.DefaultConfig()
+	cfg := dax.DefaultConfig()
 	cfg.HostPorts = []string{"dax://mycluster.frfx8h.clustercfg.dax.usw2.amazonaws.com:8111"}
 	cfg.Region = "us-west-2"
 	client, err := dax.New(cfg)
 
-    if err != nil {
-        panic(fmt.Errorf("unable to initialize client %v", err))
-    }
+	if err != nil {
+		panic(fmt.Errorf("unable to initialize client %v", err))
+	}
 
-    //Connecion to a secure cluster
-    secureEndpoint := "daxs://mycluster.frfx8h.clustercfg.dax.usw2.amazonaws.com"
-    secureCfg := dax.DefaultConfig()
+	//Connecion to a secure cluster
+	secureEndpoint := "daxs://mycluster.frfx8h.clustercfg.dax.usw2.amazonaws.com"
+	secureCfg := dax.DefaultConfig()
 	secureCfg.HostPorts = []string{secureEndpoint}
 	secureCfg.Region = "us-west-2"
-    
-   //WARN: Skip hostname verification of TLS connections. 
+
+	//WARN: Skip hostname verification of TLS connections. 
 	//The default is to perform hostname verification, setting this to True will skip verification. 
 	//Be sure you understand the implication of doing so, which is the inability to authenticate
 	//the cluster that you are connecting to.
-    secureCfg.SkipHostnameVerification = false
+	secureCfg.SkipHostnameVerification = false
 
-   // DialContext is an optional field in Config.
+	// DialContext is an optional field in Config.
 	// If DialContext is being set in Config for a secure/ encrypted cluster, then use dax.SecureDialContext to 
 	// return DialContext. An example of how DailContext can be set using dax.SecureDialContext is shown below.
-    secureCfg.DialContext = func(ctx context.Context, network string, address string) (net.Conn, error) {
-        // fmt.Println("Write your custom logic here")
-        dialCon, err := dax.SecureDialContext(secureEndpoint, secureCfg.SkipHostnameVerification)
-        if err != nil {
-            panic(fmt.Errorf("secure dialcontext creation failed %v", err))
-        }
-        return dialCon(ctx, network, address)
-    }
-    secureClient, err := dax.New(secureCfg)
-    if err != nil {
-        panic(fmt.Errorf("unable to initialize secure client %v", err))
-    }
-    fmt.Println("secure client created", secureClient)
+	secureCfg.DialContext = func(ctx context.Context, network string, address string) (net.Conn, error) {
+		// fmt.Println("Write your custom logic here")
+		dialCon, err := dax.SecureDialContext(secureEndpoint, secureCfg.SkipHostnameVerification)
+		if err != nil {
+			panic(fmt.Errorf("secure dialcontext creation failed %v", err))
+		}
+		return dialCon(ctx, network, address)
+	}
+	secureClient, err := dax.New(secureCfg)
+	if err != nil {
+		panic(fmt.Errorf("unable to initialize secure client %v", err))
+	}
+	fmt.Println("secure client created", secureClient)
 
-    // Marshal the values
-    pkVal, err := attributevalue.Marshal("mykey")
-    if err != nil {
-        return fmt.Errorf("error marshaling pk value: %v", err)
-    }
+	// Marshal the values
+	pkVal, err := attributevalue.Marshal("mykey")
+	if err != nil {
+		return fmt.Errorf("error marshaling pk value: %v", err)
+	}
 
-    skVal, err := attributevalue.Marshal("0")
-    if err != nil {
-        return fmt.Errorf("error marshaling sk value: %v", err)
-    }
+	skVal, err := attributevalue.Marshal("0")
+	if err != nil {
+		return fmt.Errorf("error marshaling sk value: %v", err)
+	}
 
-    valueVal, err := attributevalue.Marshal("myvalue")
-    if err != nil {
-        return fmt.Errorf("error marshaling value: %v", err)
-    }
+	valueVal, err := attributevalue.Marshal("myvalue")
+	if err != nil {
+		return fmt.Errorf("error marshaling value: %v", err)
+	}
 
-    // PutItem operation
-    input := &dynamodb.PutItemInput{
-        TableName: aws.String("TryDaxGoTable"),
-        Item: map[string]types.AttributeValue{
-            "pk":    pkVal,
-            "sk":    skVal,
-            "value": valueVal,
-        },
-    }
+	// PutItem operation
+	input := &dynamodb.PutItemInput{
+		TableName: aws.String("TryDaxGoTable"),
+		Item: map[string]types.AttributeValue{
+			"pk":    pkVal,
+			"sk":    skVal,
+			"value": valueVal,
+		},
+	}
 
-    output, err := client.PutItem(ctx, input)
-    if err != nil {
-        panic(fmt.Errorf("unable to make request %v", err))
-    }
+	output, err := client.PutItem(ctx, input)
+	if err != nil {
+		panic(fmt.Errorf("unable to make request %v", err))
+	}
 
-    fmt.Println("Output: ", output)
+	fmt.Println("Output: ", output)
 
 	// Scan with pagination example using DAX paginator
-    scanInput := &dynamodb.ScanInput{
-        TableName: aws.String("TryDaxGoTable"),
-        Limit:     aws.Int32(10), // Items per page
-    }
+	scanInput := &dynamodb.ScanInput{
+		TableName: aws.String("TryDaxGoTable"),
+		Limit:     aws.Int32(10), // Items per page
+	}
 
-    // Create paginator
-    paginator := dax.NewScanPaginator(client, scanInput)
+	// Create paginator
+	paginator := dax.NewScanPaginator(client, scanInput)
 
-    // Iterate through pages
-    pageNum := 0
-    for paginator.HasMorePages() {
-        pageNum++
-        fmt.Printf("Processing page %d\n", pageNum)
+	// Iterate through pages
+	pageNum := 0
+	for paginator.HasMorePages() {
+		pageNum++
+		fmt.Printf("Processing page %d\n", pageNum)
 
-        // Get next page
-        page, err := paginator.NextPage(ctx)
-        if err != nil {
-            panic(fmt.Errorf("failed to get page %d: %v", pageNum, err))
-        }
+		// Get next page
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			panic(fmt.Errorf("failed to get page %d: %v", pageNum, err))
+		}
 
-        // Process items in the page
-        for _, item := range page.Items {
-            fmt.Printf("Item: %v\n", item)
-        }
-    }
+		// Process items in the page
+		for _, item := range page.Items {
+			fmt.Printf("Item: %v\n", item)
+		}
+	}
+}
+```
+
+## Metrics
+
+The Dax SDK produces a number of metrics which can be sent to CloudWatch or any other logging platform.
+You simply have to provide a meter provider which satisfies
+the [MeterProvider](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#MeterProvider) interface
+from [smithy-go](https://github.com/aws/smithy-go).
+
+See the [example](#example-with-meter-provider) below.
+
+### List of metrics
+
+| Type                  | Metric Name                            | Metric Type                                                                                  | Description                                                         |
+|-----------------------|----------------------------------------|----------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| Operation Metrics     | `dax.op.API_OPERATION_NAME.success`    | [Int64Counter](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Counter)     | The number of successful calls for each operation                   |
+| Operation Metrics     | `dax.op.API_OPERATION_NAME.failure`    | [Int64Counter](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Counter)     | The number of failed calls for each operation                       |
+| Operation Metrics     | `dax.op.API_OPERATION_NAME.latency_us` | [Int64Histogram](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Histogram) | The latency in microseconds for each operation                      |
+| Connection Metrics    | `dax.connections.created`              | [Int64Counter](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Counter)     | Total amount of created connections                                 |
+| Connection Metrics    | `dax.connections.closed.error`         | [Int64Counter](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Counter)     | Number of closed connections due to errors                          |
+| Connection Metrics    | `dax.connections.closed.idle`          | [Int64Counter](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Counter)     | Number of closed connections due to inactivity                      |
+| Connection Metrics    | `dax.connections.closed.session`       | [Int64Counter](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Counter)     | Number of closed connections due to poll session change             |
+| Connection Metrics    | `dax.connections.attempts`             | [Int64Gauge](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Gauge)         | Current number of concurrent connection attempts                    |
+| Connection Metrics    | `dax.connections.idle`                 | [Int64Gauge](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Gauge)         | Current number of inactive connections in the pool                  |
+| Route Manager Metrics | `dax.route_manager.routes.added`       | [Int64Counter](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Counter)     | The number of routes added back to the active pool.                 |              
+| Route Manager Metrics | `dax.route_manager.routes.removed`     | [Int64Counter](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Counter)     | The number of routes removed from the active pool due to problems.  |  
+| Route Manager Metrics | `dax.route_manager.fail_open.events`   | [Int64Counter](https://pkg.go.dev/github.com/aws/smithy-go@v1.22.3/metrics#Int64Counter)     | The number of events when the manager enters the "fail-open" state. |
+
+| `API_OPERATION_NAME` |
+|----------------------|
+| `BatchGetItem`       |
+| `BatchWriteItem`     |
+| `DeleteItem`         |
+| `GetItem`            |
+| `PutItem`            |
+| `Query`              |
+| `Scan`               |
+| `TransactGetItems`   |
+| `TransactWriteItems` |
+| `UpdateItem`         |
+
+### Example with Meter Provider:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-dax-go-v2/dax"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go/metrics"
+)
+
+func main() {
+	region := "eu-west-1"
+	cfg, err := config.LoadDefaultConfig(
+		context.Background(),
+		config.WithRegion(region),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	cw := cloudwatch.NewFromConfig(cfg)
+	if cw == nil {
+		panic("unable to create cloudwatch client")
+	}
+
+	daxCfg := dax.NewConfig(cfg, "dax://mycluster.frfx8h.clustercfg.dax.usw2.amazonaws.com:8111")
+	// enable route manager health check (will generate metrics if enabled)
+	daxCfg.RouteManagerEnabled = true
+	daxCfg.MeterProvider = &MyMeterProvider{cw: *cw}
+
+	dax, err := dax.New(daxCfg)
+	if err != nil {
+		panic(err)
+	}
+
+	_, _ = dax.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("mytable"),
+		Key: map[string]ddbtypes.AttributeValue{
+			"pk": &ddbtypes.AttributeValueMemberN{Value: "251"},
+			"sk": &ddbtypes.AttributeValueMemberN{Value: "1"},
+		},
+	})
+}
+
+type MyMeterProvider struct {
+	cw cloudwatch.Client
+
+	meters map[string]metrics.Meter
+}
+
+func (m *MyMeterProvider) Meter(scope string, _ ...metrics.MeterOption) metrics.Meter {
+	if m.meters == nil {
+		m.meters = make(map[string]metrics.Meter)
+	}
+
+	mtr := m.meters[scope]
+	if mtr != nil {
+		return mtr
+	}
+
+	mtr = &MyMeter{scope: scope, cw: m.cw}
+	m.meters[scope] = mtr
+
+	return mtr
+}
+
+type MyMeter struct {
+	scope string
+	cw    cloudwatch.Client
+
+	counters   map[string]metrics.Int64Counter
+	histograms map[string]metrics.Int64Histogram
+	gauges     map[string]metrics.Int64Gauge
+}
+
+func (m *MyMeter) Int64Counter(name string, _ ...metrics.InstrumentOption) (metrics.Int64Counter, error) {
+	if m.counters == nil {
+		m.counters = make(map[string]metrics.Int64Counter)
+	}
+
+	c := m.counters[name]
+	if c != nil {
+		return c, nil
+	}
+
+	c = &MyInstrument{scope: m.scope, name: name, cw: m.cw}
+	m.counters[name] = c
+
+	return c, nil
+}
+
+func (m *MyMeter) Int64UpDownCounter(_ string, _ ...metrics.InstrumentOption) (metrics.Int64UpDownCounter, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Int64Gauge(name string, _ ...metrics.InstrumentOption) (metrics.Int64Gauge, error) {
+	if m.gauges == nil {
+		m.gauges = make(map[string]metrics.Int64Gauge)
+	}
+
+	g := m.gauges[name]
+	if g != nil {
+		return g, nil
+	}
+
+	g = &MyInstrument{scope: m.scope, name: name, cw: m.cw}
+	m.gauges[name] = g
+
+	return g, nil
+}
+
+func (m *MyMeter) Int64Histogram(name string, _ ...metrics.InstrumentOption) (metrics.Int64Histogram, error) {
+	if m.histograms == nil {
+		m.histograms = make(map[string]metrics.Int64Histogram)
+	}
+
+	h := m.histograms[name]
+	if h != nil {
+		return h, nil
+	}
+
+	h = &MyInstrument{scope: m.scope, name: name, cw: m.cw}
+	m.histograms[name] = h
+
+	return h, nil
+}
+
+func (m *MyMeter) Int64AsyncCounter(_ string, _ metrics.Int64Callback, _ ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Int64AsyncUpDownCounter(_ string, _ metrics.Int64Callback, _ ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Int64AsyncGauge(_ string, _ metrics.Int64Callback, _ ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Float64Counter(_ string, _ ...metrics.InstrumentOption) (metrics.Float64Counter, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Float64UpDownCounter(_ string, _ ...metrics.InstrumentOption) (metrics.Float64UpDownCounter, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Float64Gauge(_ string, _ ...metrics.InstrumentOption) (metrics.Float64Gauge, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Float64Histogram(_ string, _ ...metrics.InstrumentOption) (metrics.Float64Histogram, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Float64AsyncCounter(name string, callback metrics.Float64Callback, opts ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Float64AsyncUpDownCounter(name string, callback metrics.Float64Callback, opts ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	panic("not used")
+}
+
+func (m *MyMeter) Float64AsyncGauge(name string, callback metrics.Float64Callback, opts ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	panic("not used")
+}
+
+type MyInstrument struct {
+	scope string
+	name  string
+	cw    cloudwatch.Client
+}
+
+// Sample - gauge
+func (m *MyInstrument) Sample(ctx context.Context, i int64, _ ...metrics.RecordMetricOption) {
+	_, _ = m.cw.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{
+		Namespace: aws.String(m.scope),
+		MetricData: []types.MetricDatum{
+			{
+				MetricName: aws.String(m.name),
+				Values:     []float64{float64(i)},
+			},
+		},
+	})
+}
+
+// Record - histogram
+func (m *MyInstrument) Record(ctx context.Context, i int64, option ...metrics.RecordMetricOption) {
+	_, _ = m.cw.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{
+		Namespace: aws.String(m.scope),
+		MetricData: []types.MetricDatum{
+			{
+				MetricName: aws.String(m.name),
+				Values:     []float64{float64(i)},
+			},
+		},
+	})
+}
+
+// Add - Counter
+func (m *MyInstrument) Add(ctx context.Context, i int64, option ...metrics.RecordMetricOption) {
+	_, _ = m.cw.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{
+		Namespace: aws.String(m.scope),
+		MetricData: []types.MetricDatum{
+			{
+				MetricName: aws.String(m.name),
+				Values:     []float64{float64(i)},
+			},
+		},
+	})
 }
 ```
 
 ## Feedback and contributing
+
 **GitHub issues:** To provide feedback or report bugs, file GitHub
 [Issues](https://github.com/aws/aws-dax-go-v2/issues) on the SDK.
 This is the preferred mechanism to give feedback so that other users can engage in

--- a/dax/internal/client/cluster_test.go
+++ b/dax/internal/client/cluster_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/logging"
+	"github.com/aws/smithy-go/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -785,7 +786,7 @@ func TestCluster_RouteManagerDisabled(t *testing.T) {
 	}
 
 	oldRoutes := cluster.getAllRoutes()
-	route, _ := clientBuilder.newClient(net.IP{}, 8111, connConfig{}, "dummy", nil, 10, nil, nil)
+	route, _ := clientBuilder.newClient(net.IP{}, 8111, connConfig{}, "dummy", nil, 10, nil, nil, nil)
 	cluster.addRoute("dummy", route)
 	newRoutes := cluster.getAllRoutes()
 
@@ -807,7 +808,7 @@ func TestCluster_RouteManagerEnabled(t *testing.T) {
 		t.Errorf("Route manager should be enabled!")
 	}
 	oldRoutes := cluster.getAllRoutes()
-	route, _ := clientBuilder.newClient(net.IP{}, 8111, connConfig{}, "dummy", nil, 10, nil, nil)
+	route, _ := clientBuilder.newClient(net.IP{}, 8111, connConfig{}, "dummy", nil, 10, nil, nil, nil)
 	cluster.addRoute("dummy", route)
 	newRoutes := cluster.getAllRoutes()
 
@@ -962,6 +963,7 @@ func TestCluster_customDialer(t *testing.T) {
 		HostPorts:                    []string{"localhost:9121"},
 		logger:                       &logging.Nop{},
 		IdleConnectionReapDelay:      30 * time.Second,
+		MeterProvider:                &metrics.NopMeterProvider{},
 	}
 	cc, err := New(cfg)
 	require.NoError(t, err)
@@ -1263,7 +1265,7 @@ type testClientBuilder struct {
 
 var _ clientBuilder = (*testClientBuilder)(nil)
 
-func (b *testClientBuilder) newClient(ip net.IP, port int, _ connConfig, _ string, _ aws.CredentialsProvider, _ int, _ dialContext, _ RouteListener) (DaxAPI, error) {
+func (b *testClientBuilder) newClient(ip net.IP, port int, _ connConfig, _ string, _ aws.CredentialsProvider, _ int, _ dialContext, _ RouteListener, _ *daxSdkMetrics) (DaxAPI, error) {
 	t := &testClient{ep: b.ep, hp: hostPort{ip.String(), port}}
 	b.clients = append(b.clients, []*testClient{t}...)
 	return t, nil

--- a/dax/internal/client/health_status.go
+++ b/dax/internal/client/health_status.go
@@ -37,8 +37,14 @@ type enabledHealthStatus struct {
 
 func newHealthStatus(endpoint string, routeListener RouteListener) HealthStatus {
 	if routeListener != nil && routeListener.isRouteManagerEnabled() {
-		return &enabledHealthStatus{routeListener: routeListener, endpoint: endpoint, lock: sync.RWMutex{}, isHealthy: true}
+		return &enabledHealthStatus{
+			routeListener: routeListener,
+			endpoint:      endpoint,
+			lock:          sync.RWMutex{},
+			isHealthy:     true,
+		}
 	}
+
 	return &disabledHealthStatus{}
 }
 
@@ -58,6 +64,7 @@ func (hs *enabledHealthStatus) onErrorInReadRequest(err error, route DaxAPI) {
 	hs.curReadTimeoutCount += 1
 	if hs.curReadTimeoutCount >= timeoutErrorThreshold {
 		hs.isHealthy = false
+
 		hs.routeListener.removeRoute(hs.endpoint, route)
 	}
 }
@@ -90,6 +97,7 @@ func (hs *enabledHealthStatus) onHealthCheckSuccess(route DaxAPI) {
 	hs.curReadTimeoutCount = 0
 	if !hs.isHealthy {
 		hs.isHealthy = true
+
 		hs.routeListener.addRoute(hs.endpoint, route)
 	}
 }

--- a/dax/internal/client/metrics.go
+++ b/dax/internal/client/metrics.go
@@ -1,0 +1,246 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/smithy-go/metrics"
+)
+
+const (
+	daxMeterScope = "github.com/aws/aws-dax-go-v2"
+
+	daxOpNameSuccess                = "dax.op.%s.success"
+	daxOpNameFailure                = "dax.op.%s.failure"
+	daxOpNameLatencyUs              = "dax.op.%s.latency_us"     // histogram
+	daxConnectionsIdle              = "dax.connections.idle"     // gauge
+	daxConcurrentConnectionAttempts = "dax.connections.attempts" // gauge
+	daxConnectionsCreated           = "dax.connections.created"
+	daxConnectionsClosedError       = "dax.connections.closed.error"
+	daxConnectionsClosedIdle        = "dax.connections.closed.idle"
+	daxConnectionsClosedSession     = "dax.connections.closed.session"
+	daxRouteManagerRoutesAdded      = "dax.route_manager.routes.added"
+	daxRouteManagerRoutesRemoved    = "dax.route_manager.routes.removed"
+	daxRouteManagerFailOpenEvents   = "dax.route_manager.fail_open.events"
+)
+
+type daxSdkMetrics struct {
+	counters   map[string]metrics.Int64Counter
+	histograms map[string]metrics.Int64Histogram
+	gauges     map[string]metrics.Int64Gauge
+}
+
+func (m *daxSdkMetrics) counterFor(name string) metrics.Int64Counter {
+	return m.counters[name]
+}
+
+func (m *daxSdkMetrics) histogramFor(name string) metrics.Int64Histogram {
+	return m.histograms[name]
+}
+
+func (m *daxSdkMetrics) gaugeFor(name string) metrics.Int64Gauge {
+	return m.gauges[name]
+}
+
+func buildCounters(meter metrics.Meter, om *daxSdkMetrics, ops []string) (err error) {
+	counters := map[string]string{
+		daxOpNameSuccess:              "Operations %s success",
+		daxOpNameFailure:              "Operations %s failure",
+		daxConnectionsCreated:         "Total amount of created connections",
+		daxConnectionsClosedError:     "Number of closed connections due to errors",
+		daxConnectionsClosedIdle:      "Number of closed connections due to inactivity",
+		daxConnectionsClosedSession:   "Number of closed connections due to poll session change",
+		daxRouteManagerRoutesAdded:    "The number of routes added back to the active pool.",
+		daxRouteManagerRoutesRemoved:  "The number of routes removed from the active pool due to problems.",
+		daxRouteManagerFailOpenEvents: `The number of events when the manager enters the "fail-open" state.`,
+	}
+
+	for name, description := range counters {
+		if strings.Contains(name, "%s") {
+			for _, op := range ops {
+				metricName := fmt.Sprintf(name, op)
+				metricDescription := fmt.Sprintf(description, op)
+
+				om.counters[metricName], err = operationCounter(meter, metricName, metricDescription)
+
+				if err != nil {
+					return
+				}
+			}
+
+			continue
+		}
+
+		om.counters[name], err = operationCounter(meter, name, description)
+
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func buildHistograms(meter metrics.Meter, om *daxSdkMetrics, ops []string) (err error) {
+	histograms := map[string]string{
+		daxOpNameLatencyUs: "Operations %s latency in microseconds",
+	}
+
+	// build histograms
+	for name, description := range histograms {
+		if strings.Contains(name, "%s") {
+			for _, op := range ops {
+				metricName := fmt.Sprintf(name, op)
+				metricDescription := fmt.Sprintf(description, op)
+
+				om.histograms[metricName], err = operationHistogram(meter, metricName, metricDescription)
+
+				if err != nil {
+					return
+				}
+			}
+
+			continue
+		}
+
+		om.histograms[name], err = operationHistogram(meter, name, description)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func buildGauges(meter metrics.Meter, om *daxSdkMetrics, ops []string) (err error) {
+	gauges := map[string]string{
+		daxConnectionsIdle:              "Current number of inactive connections in the pool",
+		daxConcurrentConnectionAttempts: "Current number of concurrent connection attempts",
+	}
+
+	// build gauges
+	for name, description := range gauges {
+		om.gauges[name], err = operationGauge(meter, name, description)
+
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func buildDaxSdkMetrics(mp metrics.MeterProvider) (*daxSdkMetrics, error) {
+	meter := mp.Meter(daxMeterScope)
+
+	sdkMetrics := &daxSdkMetrics{
+		counters:   make(map[string]metrics.Int64Counter),
+		histograms: make(map[string]metrics.Int64Histogram),
+		gauges:     make(map[string]metrics.Int64Gauge),
+	}
+
+	ops := []string{
+		OpGetItem,
+		OpPutItem,
+		OpUpdateItem,
+		OpDeleteItem,
+		OpBatchGetItem,
+		OpBatchWriteItem,
+		OpTransactGetItems,
+		OpTransactWriteItems,
+		OpQuery,
+		OpScan,
+	}
+
+	if err := buildCounters(meter, sdkMetrics, ops); err != nil {
+		return nil, err
+	}
+
+	if err := buildHistograms(meter, sdkMetrics, ops); err != nil {
+		return nil, err
+	}
+
+	if err := buildGauges(meter, sdkMetrics, ops); err != nil {
+		return nil, err
+	}
+
+	return sdkMetrics, nil
+}
+
+func operationCounter(m metrics.Meter, name string, description string) (metrics.Int64Counter, error) {
+	return m.Int64Counter(name, func(o *metrics.InstrumentOptions) {
+		o.Description = description
+	})
+}
+
+func operationHistogram(m metrics.Meter, name string, description string) (metrics.Int64Histogram, error) {
+	return m.Int64Histogram(name, func(o *metrics.InstrumentOptions) {
+		o.UnitLabel = "Microseconds"
+		o.Description = description
+	})
+}
+
+func operationGauge(m metrics.Meter, name string, description string) (metrics.Int64Gauge, error) {
+	return m.Int64Gauge(name, func(o *metrics.InstrumentOptions) {
+		o.Description = description
+	})
+}
+
+type metricFunction[T any] func() (T, error)
+
+func countMetricInt64(ctx context.Context, om *daxSdkMetrics, name string, v int64) {
+	c := om.counterFor(name)
+
+	if c == nil {
+		return
+	}
+
+	c.Add(ctx, v)
+}
+
+func gaugeInt64(ctx context.Context, om *daxSdkMetrics, name string, v int64) {
+	g := om.gaugeFor(name)
+
+	if g == nil {
+		return
+	}
+
+	g.Sample(ctx, v)
+}
+
+func histogramMicrosecondsInt64(ctx context.Context, om *daxSdkMetrics, name string, t time.Time) {
+	h := om.histogramFor(name)
+
+	if h == nil {
+		return
+	}
+
+	h.Record(ctx, time.Since(t).Microseconds())
+}
+
+func withMicrosecondHistogramInt64[T any](ctx context.Context, om *daxSdkMetrics, name string, fn metricFunction[T]) (T, error) {
+	startTime := time.Now()
+
+	out, err := fn()
+
+	histogramMicrosecondsInt64(ctx, om, name, startTime)
+
+	return out, err
+}

--- a/dax/internal/client/metrics_test.go
+++ b/dax/internal/client/metrics_test.go
@@ -1,0 +1,225 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountMetricInt64(t *testing.T) {
+	mp := &testMeterProvider{}
+	om, _ := buildDaxSdkMetrics(mp)
+
+	countMetricInt64(context.TODO(), om, fmt.Sprintf(daxOpNameFailure, OpGetItem), 1)
+
+	assert.Len(t, mp.meters, 1)
+	s, ok := mp.meters[daxMeterScope]
+	assert.True(t, ok, fmt.Sprintf(`expected key "%s" to exist in meters map`, daxMeterScope))
+	assert.NotNil(t, s)
+	if !ok || s == nil {
+		return
+	}
+
+	tm, ok := s.(*testMeter)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+
+	keys := map[string]int{
+		fmt.Sprintf(daxOpNameFailure, OpGetItem): 1,
+	}
+
+	for k, v := range keys {
+		i, ok := tm.i64s[k]
+		assert.True(t, ok, fmt.Sprintf(`expected key "%s" to exist in meters map`, k))
+		assert.Equal(t, v, len(i.data), k)
+	}
+}
+
+func TestGaugeInt64(t *testing.T) {
+	mp := &testMeterProvider{}
+	om, _ := buildDaxSdkMetrics(mp)
+
+	gaugeInt64(context.TODO(), om, daxConnectionsIdle, 1)
+
+	assert.Len(t, mp.meters, 1)
+	s, ok := mp.meters[daxMeterScope]
+	assert.True(t, ok, fmt.Sprintf(`expected key "%s" to exist in meters map`, daxMeterScope))
+	assert.NotNil(t, s)
+	if !ok || s == nil {
+		return
+	}
+
+	tm, ok := s.(*testMeter)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+
+	keys := map[string]int{
+		daxConnectionsIdle: 1,
+	}
+
+	for k, v := range keys {
+		i, ok := tm.i64s[k]
+		assert.True(t, ok, fmt.Sprintf(`expected key "%s" to exist in meters map`, k))
+		assert.Equal(t, v, len(i.data), k)
+	}
+}
+
+func TestHistogramMicrosecondsInt64(t *testing.T) {
+	mp := &testMeterProvider{}
+	om, _ := buildDaxSdkMetrics(mp)
+
+	startTime := time.Now()
+	histogramMicrosecondsInt64(context.TODO(), om, fmt.Sprintf(daxOpNameLatencyUs, OpGetItem), startTime)
+
+	assert.Len(t, mp.meters, 1)
+	s, ok := mp.meters[daxMeterScope]
+	assert.True(t, ok, fmt.Sprintf(`expected key "%s" to exist in meters map`, daxMeterScope))
+	assert.NotNil(t, s)
+	if !ok || s == nil {
+		return
+	}
+
+	tm, ok := s.(*testMeter)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+
+	keys := map[string]int{
+		fmt.Sprintf(daxOpNameLatencyUs, OpGetItem): 1,
+	}
+
+	for k, v := range keys {
+		i, ok := tm.i64s[k]
+		assert.True(t, ok, fmt.Sprintf(`expected key "%s" to exist in meters map`, k))
+		assert.Equal(t, v, len(i.data), k)
+	}
+
+}
+
+func TestWithMicrosecondHistogramInt64(t *testing.T) {
+	mp := &testMeterProvider{}
+	om, _ := buildDaxSdkMetrics(mp)
+
+	_, _ = withMicrosecondHistogramInt64(
+		context.TODO(),
+		om,
+		fmt.Sprintf(daxOpNameLatencyUs, OpGetItem),
+		func() (any, error) {
+			return nil, nil
+		},
+	)
+
+	assert.Len(t, mp.meters, 1)
+	s, ok := mp.meters[daxMeterScope]
+	assert.True(t, ok, fmt.Sprintf(`expected key "%s" to exist in meters map`, daxMeterScope))
+	assert.NotNil(t, s)
+	if !ok || s == nil {
+		return
+	}
+
+	tm, ok := s.(*testMeter)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+
+	keys := map[string]int{
+		fmt.Sprintf(daxOpNameLatencyUs, OpGetItem): 1,
+	}
+
+	for k, v := range keys {
+		i, ok := tm.i64s[k]
+		assert.True(t, ok, fmt.Sprintf(`expected key "%s" to exist in meters map`, k))
+		assert.Equal(t, v, len(i.data), k)
+	}
+}
+
+func BenchmarkCountMetricInt64Nop(b *testing.B) {
+	mp := &testMeterProvider{}
+	om, _ := buildDaxSdkMetrics(mp)
+	ctx := context.TODO()
+
+	for range b.N {
+		countMetricInt64(ctx, om, daxConnectionsCreated, 1)
+	}
+}
+
+func BenchmarkCountMetricInt64Test(b *testing.B) {
+	mp := &testMeterProvider{}
+	om, _ := buildDaxSdkMetrics(mp)
+	ctx := context.TODO()
+
+	for range b.N {
+		countMetricInt64(ctx, om, daxConnectionsCreated, 1)
+	}
+}
+
+func BenchmarkGaugeInt64Nop(b *testing.B) {
+	mp := &testMeterProvider{}
+	om, _ := buildDaxSdkMetrics(mp)
+	ctx := context.TODO()
+
+	for range b.N {
+		gaugeInt64(ctx, om, daxConnectionsIdle, 1)
+	}
+}
+
+func BenchmarkGaugeInt64Test(b *testing.B) {
+	mp := &testMeterProvider{}
+	om, _ := buildDaxSdkMetrics(mp)
+	ctx := context.TODO()
+
+	for range b.N {
+		gaugeInt64(ctx, om, daxConnectionsIdle, 1)
+	}
+}
+
+func BenchmarkHistogramMicrosecondsInt64Nop(b *testing.B) {
+	mp := &testMeterProvider{}
+	om, err := buildDaxSdkMetrics(mp)
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.TODO()
+	startTime := time.Now()
+	name := fmt.Sprintf(daxOpNameLatencyUs, OpGetItem)
+
+	for range b.N {
+		histogramMicrosecondsInt64(ctx, om, name, startTime)
+	}
+}
+
+func BenchmarkHistogramMicrosecondsInt64Test(b *testing.B) {
+	mp := &testMeterProvider{}
+	om, _ := buildDaxSdkMetrics(mp)
+	ctx := context.TODO()
+	startTime := time.Now()
+	name := fmt.Sprintf(daxOpNameLatencyUs, OpGetItem)
+
+	for range b.N {
+		histogramMicrosecondsInt64(ctx, om, name, startTime)
+	}
+}

--- a/dax/internal/client/shared_test.go
+++ b/dax/internal/client/shared_test.go
@@ -1,0 +1,235 @@
+/*
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/smithy-go/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+// testMeterProvider is naive metrics implementation for testing purposes
+type testMeterProvider struct {
+	meters map[string]metrics.Meter
+}
+
+var _ metrics.MeterProvider = (*testMeterProvider)(nil)
+
+// Meter returns a meter which creates no-op instruments.
+func (t *testMeterProvider) Meter(name string, _ ...metrics.MeterOption) metrics.Meter {
+	if t.meters == nil {
+		t.meters = map[string]metrics.Meter{}
+	}
+
+	if out, ok := t.meters[name]; ok {
+		return out
+	}
+
+	out := &testMeter{}
+
+	t.meters[name] = out
+
+	return out
+}
+
+type testMeter struct {
+	i64s map[string]*testInstrument[int64]
+	f64s map[string]*testInstrument[float64]
+}
+
+var _ metrics.Meter = (*testMeter)(nil)
+
+func (t *testMeter) instrumentInt64(name string) *testInstrument[int64] {
+	if t.i64s == nil {
+		t.i64s = map[string]*testInstrument[int64]{}
+	}
+
+	if out, ok := t.i64s[name]; ok {
+		return out
+	}
+
+	out := &testInstrument[int64]{}
+
+	t.i64s[name] = out
+
+	return out
+}
+
+func (t *testMeter) instrumentFloat64(name string) *testInstrument[float64] {
+	if t.f64s == nil {
+		t.f64s = map[string]*testInstrument[float64]{}
+	}
+
+	if out, ok := t.f64s[name]; ok {
+		return out
+	}
+
+	out := &testInstrument[float64]{}
+
+	t.f64s[name] = out
+
+	return out
+}
+
+func (t *testMeter) Int64Counter(name string, _ ...metrics.InstrumentOption) (metrics.Int64Counter, error) {
+	return t.instrumentInt64(name), nil
+}
+func (t *testMeter) Int64UpDownCounter(name string, _ ...metrics.InstrumentOption) (metrics.Int64UpDownCounter, error) {
+	return t.instrumentInt64(name), nil
+}
+func (t *testMeter) Int64Gauge(name string, _ ...metrics.InstrumentOption) (metrics.Int64Gauge, error) {
+	return t.instrumentInt64(name), nil
+}
+func (t *testMeter) Int64Histogram(name string, _ ...metrics.InstrumentOption) (metrics.Int64Histogram, error) {
+	return t.instrumentInt64(name), nil
+}
+func (t *testMeter) Int64AsyncCounter(name string, _ metrics.Int64Callback, _ ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	return t.instrumentInt64(name), nil
+}
+func (t *testMeter) Int64AsyncUpDownCounter(name string, _ metrics.Int64Callback, _ ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	return t.instrumentInt64(name), nil
+}
+func (t *testMeter) Int64AsyncGauge(name string, _ metrics.Int64Callback, _ ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	return t.instrumentInt64(name), nil
+}
+func (t *testMeter) Float64Counter(name string, _ ...metrics.InstrumentOption) (metrics.Float64Counter, error) {
+	return t.instrumentFloat64(name), nil
+}
+func (t *testMeter) Float64UpDownCounter(name string, _ ...metrics.InstrumentOption) (metrics.Float64UpDownCounter, error) {
+	return t.instrumentFloat64(name), nil
+}
+func (t *testMeter) Float64Gauge(name string, _ ...metrics.InstrumentOption) (metrics.Float64Gauge, error) {
+	return t.instrumentFloat64(name), nil
+}
+func (t *testMeter) Float64Histogram(name string, _ ...metrics.InstrumentOption) (metrics.Float64Histogram, error) {
+	return t.instrumentFloat64(name), nil
+}
+func (t *testMeter) Float64AsyncCounter(name string, _ metrics.Float64Callback, _ ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	return t.instrumentFloat64(name), nil
+}
+func (t *testMeter) Float64AsyncUpDownCounter(name string, _ metrics.Float64Callback, _ ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	return t.instrumentFloat64(name), nil
+}
+func (t *testMeter) Float64AsyncGauge(name string, _ metrics.Float64Callback, _ ...metrics.InstrumentOption) (metrics.AsyncInstrument, error) {
+	return t.instrumentFloat64(name), nil
+}
+
+type testInstrument[N int64 | float64] struct {
+	data      []N
+	callbacks []any
+	stopCh    chan bool
+}
+
+func (t *testInstrument[N]) Add(_ context.Context, n N, _ ...metrics.RecordMetricOption) {
+	if len(t.data) == 0 {
+		t.data = append(t.data, n)
+	} else {
+		t.data[0] += n
+	}
+}
+
+func (t *testInstrument[N]) Sample(_ context.Context, n N, _ ...metrics.RecordMetricOption) {
+	t.data = []N{n}
+}
+
+func (t *testInstrument[N]) Record(_ context.Context, n N, _ ...metrics.RecordMetricOption) {
+	t.data = append(t.data, n)
+}
+
+func (testInstrument[_]) Stop() {}
+
+func counter(om *daxSdkMetrics, name string) (metrics.Int64Counter, bool, int) {
+	c, ok := om.counters[name]
+	val := 0
+	if c != nil {
+		if i, iOk := c.(*testInstrument[int64]); iOk && len(i.data) > 0 {
+			val = int(i.data[len(i.data)-1])
+		}
+	}
+	return c, ok, val
+}
+
+func gauge(om *daxSdkMetrics, name string) (metrics.Int64Gauge, bool, int) {
+	g, ok := om.gauges[name]
+	val := 0
+	if g != nil {
+		if i, iOk := g.(*testInstrument[int64]); iOk && len(i.data) > 0 {
+			val = int(i.data[0])
+		}
+	}
+	return g, ok, val
+}
+
+func histogram(om *daxSdkMetrics, name string) (metrics.Int64Histogram, bool, int) {
+	h, ok := om.histograms[name]
+	val := 0
+	if h != nil {
+		if i, iOk := h.(*testInstrument[int64]); iOk && len(i.data) > 0 {
+			val = len(i.data)
+		}
+	}
+	return h, ok, val
+}
+
+func expectCounters(t *testing.T, om *daxSdkMetrics, counters map[string]int) {
+	for k, v := range counters {
+		c, exists, cnt := counter(om, k)
+		assert.NotNil(t, c, k)
+		assert.True(t, exists)
+		if v != -1 {
+			assert.Equal(t, v, cnt, k)
+		} else {
+			assert.Greater(t, cnt, 0, k)
+		}
+	}
+}
+
+func expectGauges(t *testing.T, om *daxSdkMetrics, gauges map[string]int) {
+	for k, v := range gauges {
+		c, exists, cnt := gauge(om, k)
+		assert.NotNil(t, c, k)
+		assert.True(t, exists)
+		if v != -1 {
+			assert.Equal(t, v, cnt, k)
+		} else {
+			assert.Greater(t, cnt, 0, k)
+		}
+	}
+}
+
+func expectHistograms(t *testing.T, om *daxSdkMetrics, histograms map[string]int) {
+	for k, v := range histograms {
+		c, exists, cnt := histogram(om, k)
+		assert.NotNil(t, c, k)
+		assert.True(t, exists)
+		if v != -1 {
+			assert.Equal(t, v, cnt, k)
+		} else {
+			assert.Greater(t, cnt, 0, k)
+		}
+	}
+}
+
+func expectMetrics(
+	t *testing.T,
+	om *daxSdkMetrics,
+	counters map[string]int,
+	gauges map[string]int,
+	histograms map[string]int,
+) {
+}


### PR DESCRIPTION
This merge requests adds support for passing a meter provider to the config that implements the `github.com/aws/smithy-go/metrics.MeterProvider` interface. By default the `github.com/aws/smithy-go/metrics.NopMeterProvider` is used. This provider drops all the data that is attempted to be written to it.

The following metrics are tracked:

- dax.op.%s.success
- dax.op.%s.failure
- dax.op.%s.latency_us
- dax.connections.idle
- dax.connections.pending_acquire
- dax.connections.created
- dax.connections.closed.error
- dax.connections.closed.idle
- dax.connections.closed.session
- dax.health_check.success
- dax.health_check.failure
- dax.route_manager.routes.added
- dax.route_manager.routes.removed
- dax.route_manager.fail_open.events
- dax.route_manager.disabled_state

The following operations are going to be tracked as `dax.op.%s...` when they go through the method `func (client *SingleDaxClient) executeWithContext()`

- DefineAttributeList
- DefineAttributeListId
- DefineKeySchema
- Endpoints
- GetItem
- PutItem
- UpdateItem
- DeleteItem
- BatchGetItem
- BatchWriteItem
- TransactGetItems
- TransactWriteItems
- Query
- Scan

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
