### PR TITLE
dax/internal/client: fix dropped error

### DIFF
--- a/dax/internal/client/response.go
+++ b/dax/internal/client/response.go
@@ -1184,7 +1184,7 @@ func decodeAttributeProjection(ctx context.Context, reader *cbor.Reader, attrLis
 		attrs[ans[ord]] = av
 		return nil
 	})
-	return attrs, nil
+	return attrs, err
 }
 
 func decodeConsumedCapacity(reader *cbor.Reader) (*types.ConsumedCapacity, error) {


### PR DESCRIPTION
This fixes a dropped `err` variable in `dax/internal/client`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
